### PR TITLE
Refactor: Switch to the old-fashoined venv layout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
-        tox-version: ["==3.18.0", "==3.19.0", "==3.20.0", ">=4.0.0a2"]
+        python-version: [3.8, 3.9, "3.10"]
+        tox-version: ["<4", ">=4.0.0b0"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: pdm-project/setup-pdm@main
         with:
@@ -28,7 +28,5 @@ jobs:
           if which tox4 > /dev/null
           then
             mv pdm.tox4.lock pdm.lock
-            tox4 -e py${pyversion/./}
-          else
-            tox -e py${pyversion/./}
           fi
+          tox -e py${pyversion/./}

--- a/pdm.tox4.lock
+++ b/pdm.tox4.lock
@@ -16,14 +16,13 @@ version = "21.12b0"
 requires_python = ">=3.6.2"
 summary = "The uncompromising code formatter."
 dependencies = [
-    "click>=7.1.2",
+    "click>=8.0.0",
     "mypy-extensions>=0.4.3",
-    "pathspec<1,>=0.9.0",
+    "pathspec>=0.9.0",
     "platformdirs>=2",
-    "tomli<2.0.0,>=0.2.6",
+    "tomli>=1.1.0; python_version < \"3.11\"",
     "typed-ast>=1.4.2; python_version < \"3.8\" and implementation_name == \"cpython\"",
-    "typing-extensions!=3.10.0.1; python_version >= \"3.10\"",
-    "typing-extensions>=3.10.0.0",
+    "typing-extensions>=3.10.0.0; python_version < \"3.10\"",
 ]
 
 [[package]]
@@ -41,7 +40,7 @@ summary = "Universal encoding detector for Python 2 and 3"
 [[package]]
 name = "click"
 version = "8.0.3"
-requires_python = ">=3.6"
+requires_python = ">=3.7"
 summary = "Composable command line interface toolkit"
 dependencies = [
     "colorama; platform_system == \"Windows\"",
@@ -57,7 +56,7 @@ summary = "Cross-platform colored terminal text."
 [[package]]
 name = "coverage"
 version = "6.2"
-requires_python = ">=3.6"
+requires_python = ">=3.7"
 summary = "Code coverage measurement for Python"
 
 [[package]]
@@ -120,6 +119,7 @@ dependencies = [
 [[package]]
 name = "pathspec"
 version = "0.9.0"
+requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 summary = "Utility library for gitignore style pattern matching of file paths."
 
 [[package]]
@@ -158,8 +158,8 @@ summary = "passive checker of Python programs"
 [[package]]
 name = "pyparsing"
 version = "3.0.6"
-requires_python = ">=3.6"
-summary = "Python parsing module"
+requires_python = ">=3.6.8"
+summary = "pyparsing module - Classes and methods to define and execute parsing grammars"
 
 [[package]]
 name = "pyproject-api"
@@ -174,7 +174,7 @@ dependencies = [
 [[package]]
 name = "pytest"
 version = "6.2.5"
-requires_python = ">=3.6"
+requires_python = ">=3.7"
 summary = "pytest: simple powerful testing with Python"
 dependencies = [
     "atomicwrites>=1.0; sys_platform == \"win32\"",
@@ -185,7 +185,7 @@ dependencies = [
     "packaging",
     "pluggy<2.0,>=0.12",
     "py>=1.8.2",
-    "toml",
+    "tomli>=1.0.0",
 ]
 
 [[package]]
@@ -203,12 +203,12 @@ summary = "Python Library for Tom's Obvious, Minimal Language"
 [[package]]
 name = "tomli"
 version = "1.2.3"
-requires_python = ">=3.6"
+requires_python = ">=3.7"
 summary = "A lil' TOML parser"
 
 [[package]]
 name = "tox"
-version = "4.0.0a10"
+version = "4.0.0b2"
 requires_python = ">=3.7"
 summary = "tox is a generic virtualenv management and test command line tool"
 dependencies = [
@@ -234,8 +234,8 @@ summary = "a fork of Python 2 and 3 ast modules with type comment support"
 [[package]]
 name = "typing-extensions"
 version = "4.0.1"
-requires_python = ">=3.6"
-summary = "Backported and Experimental Type Hints for Python 3.6+"
+requires_python = ">=3.7"
+summary = "Backported and Experimental Type Hints for Python 3.7+"
 
 [[package]]
 name = "virtualenv"
@@ -418,9 +418,9 @@ content_hash = "sha256:0671915afd3ae5b6a844751e2c1d7fd939657bca2bff08e2b12b4fdac
     {file = "tomli-1.2.3-py3-none-any.whl", hash = "sha256:e3069e4be3ead9668e21cb9b074cd948f7b3113fd9c8bba083f48247aab8b11c"},
     {file = "tomli-1.2.3.tar.gz", hash = "sha256:05b6166bff487dc068d322585c7ea4ef78deed501cc124060e0f238e89a9231f"},
 ]
-"tox 4.0.0a10" = [
-    {file = "tox-4.0.0a10-py3-none-any.whl", hash = "sha256:292061a90535a547d6bc66048260d845912f3de4054e2584af2d2d317ea1fd90"},
-    {file = "tox-4.0.0a10.tar.gz", hash = "sha256:8317a3fc6beb8c87e555cda5af5949008410e5eb53f3379dfb25160af1f6f7b6"},
+"tox 4.0.0b2" = [
+    {file = "tox-4.0.0b2-py3-none-any.whl", hash = "sha256:445fb1fe5d0b0e8ea59a66c7d03e4b829e3524e61d5905cf3387b56161484eb8"},
+    {file = "tox-4.0.0b2.tar.gz", hash = "sha256:78efc716e760390b5129bdf4f46662ff771d767085377f2d623894096f5320ea"},
 ]
 "typed-ast 1.5.1" = [
     {file = "typed_ast-1.5.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5d8314c92414ce7481eee7ad42b353943679cf6f30237b5ecbf7d835519e1212"},

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,10 +2,18 @@ import sys
 import textwrap
 
 import py
+import pytest
 from tox import __version__ as TOX_VERSION
 
 FIX_PROJECT = py.path.local(__file__).dirpath("fixture-project")
 IS_TOX_4 = TOX_VERSION[0] == "4"
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    monkeypatch.delenv("TOX_ENV_NAME", raising=False)
+    monkeypatch.delenv("TOX_WORK_DIR", raising=False)
+    monkeypatch.delenv("TOX_ENV_DIR", raising=False)
 
 
 def setup_project(tmpdir, tox_config):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -34,6 +34,7 @@ def test_install_conditional_deps(tmpdir):
         [tox]
         envlist = django{2,3}
         passenv = LD_PRELOAD
+        isolated_build = True
 
         [testenv]
         groups =
@@ -55,7 +56,7 @@ def test_install_conditional_deps(tmpdir):
                 raise RuntimeError(f"non-zero exit code: {e.code}")
 
     if TOX_VERSION[0] == "4":
-        package = tmpdir.join(".tox/4/.pkg/dist/demo-0.1.0.tar.gz")
+        package = tmpdir.join(".tox/.pkg/dist/demo-0.1.0.tar.gz")
     else:
-        package = tmpdir.join(".tox/.package/demo-0.1.0.tar.gz")
+        package = tmpdir.join(".tox/dist/demo-0.1.0.tar.gz")
     assert package.exists()

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,9 @@ ignore =
 max-line-length = 88
 
 [tox]
-envlist = py37, py38, py39, lint
+envlist = py{38,39,310}, lint
 passenv = LD_PRELOAD
+isolated_build = True
 
 [testenv]
 groups = test

--- a/tox_pdm/plugin3.py
+++ b/tox_pdm/plugin3.py
@@ -1,23 +1,9 @@
 """Plugin specification for Tox 3"""
-import functools
-import os
-import shutil
-from typing import Any, Tuple
+from typing import Any
 
-import py
-from tox import action, config, hookimpl, reporter, session
-from tox.package.view import create_session_view
-from tox.util.lock import hold_lock
-from tox.util.path import ensure_empty_dir
+from tox import action, config, hookimpl
 from tox.venv import VirtualEnv
-
-from .utils import (
-    clone_pdm_files,
-    detect_pdm_files,
-    get_env_lib_path,
-    inject_pdm_to_commands,
-    set_default_kwargs,
-)
+from tox_pdm.utils import setup_env
 
 
 @hookimpl
@@ -25,99 +11,16 @@ def tox_addoption(parser: config.Parser) -> Any:
     parser.add_testenv_attribute(
         "groups", "line-list", "Specify the dependency groups to install"
     )
-    os.environ["TOX_TESTENV_PASSENV"] = "PYTHONPATH"
+    setup_env()
     parser.add_argument("--pdm", default="pdm", help="The executable path of PDM")
-    set_default_kwargs(VirtualEnv._pcall, venv=False)
-    set_default_kwargs(VirtualEnv.getcommandpath, venv=False)
-
-
-@hookimpl
-def tox_testenv_create(venv: VirtualEnv, action: action.Action) -> Any:
-    clone_pdm_files(str(venv.path), str(venv.envconfig.config.toxinidir))
-    config_interpreter = venv.getsupportedinterpreter()
-
-    def patch_getcommandpath(getcommandpath):
-        @functools.wraps(getcommandpath)
-        def patched(self, cmd, *args, **kwargs):
-            if cmd == "python":
-                return config_interpreter
-            return getcommandpath(self, cmd, *args, **kwargs)
-
-        return patched
-
-    VirtualEnv.getcommandpath = patch_getcommandpath(VirtualEnv.getcommandpath)
-    if not venv.path.join(".pdm.toml").exists():
-        venv._pcall(
-            [venv.envconfig.config.option.pdm, "use", "-f", config_interpreter],
-            cwd=venv.path,
-            venv=False,
-            action=action,
-        )
-    return True
-
-
-def get_package(
-    session: session.Session, venv: VirtualEnv
-) -> Tuple[py.path.local, py.path.local]:
-    config = session.config
-    if config.skipsdist:
-        reporter.info("skipping sdist step")
-        return None
-    lock_file = session.config.toxworkdir.join(
-        "{}.lock".format(session.config.isolated_build_env)
-    )
-
-    with hold_lock(lock_file, reporter.verbosity0):
-        package = acquire_package(config, venv)
-        session_package = create_session_view(package, config.temp_dir)
-        return session_package, package
-
-
-def acquire_package(config: config.Config, venv: VirtualEnv) -> py.path.local:
-    target_dir: py.path.local = config.toxworkdir.join(config.isolated_build_env)
-    ensure_empty_dir(target_dir)
-    args = [
-        venv.envconfig.config.option.pdm,
-        "build",
-        "--no-wheel",
-        "-d",
-        target_dir,
-    ]
-    with venv.new_action("buildpkg") as action:
-        venv._pcall(
-            args, cwd=venv.envconfig.config.toxinidir, venv=False, action=action
-        )
-        path = next(target_dir.visit("*.tar.gz"))
-        action.setactivity("buildpkg", path)
-        return path
-
-
-@hookimpl
-def tox_package(session: session.Session, venv: VirtualEnv) -> Any:
-    with venv.new_action("buildpkg") as action:
-        tox_testenv_create(venv, action)
-    if not detect_pdm_files(venv.path):
-        return
-    if not hasattr(session, "package"):
-        session.package, session.dist = get_package(session, venv)
-    # Patch the install command to install to local __pypackages__ folder
-    for i, arg in enumerate(venv.envconfig.install_command):
-        if arg == "python":
-            venv.envconfig.install_command[i] = venv.getsupportedinterpreter()
-    venv.envconfig.install_command.extend(
-        ["-t", get_env_lib_path(venv.envconfig.config.option.pdm, venv.path)]
-    )
-    return session.package
 
 
 @hookimpl
 def tox_testenv_install_deps(venv: VirtualEnv, action: action.Action) -> Any:
-    if not detect_pdm_files(venv.path):
-        return
     groups = venv.envconfig.groups or []
     if not venv.envconfig.skip_install or groups:
         action.setactivity("pdminstall", groups)
-        args = [venv.envconfig.config.option.pdm, "install", "-p", str(venv.path)]
+        args = [venv.envconfig.config.option.pdm, "install"]
         if "default" in groups:
             groups.remove("default")
         elif venv.envconfig.skip_install:
@@ -137,43 +40,4 @@ def tox_testenv_install_deps(venv: VirtualEnv, action: action.Action) -> Any:
         depinfo = ", ".join(map(str, deps))
         action.setactivity("installdeps", depinfo)
         venv._install(deps, action=action)
-
-    lib_path = get_env_lib_path(venv.envconfig.config.option.pdm, venv.path)
-    bin_dir = os.path.join(lib_path, "bin")
-    scripts_dir = os.path.join(
-        os.path.dirname(lib_path), ("Scripts" if os.name == "nt" else "bin")
-    )
-
-    if os.path.exists(bin_dir):
-        for item in os.listdir(bin_dir):
-            bin_item = os.path.join(bin_dir, item)
-            shutil.move(bin_item, os.path.join(scripts_dir, item))
     return True
-
-
-@hookimpl
-def tox_runtest_pre(venv: VirtualEnv) -> Any:
-    if not detect_pdm_files(venv.path):
-        return
-    inject_pdm_to_commands(
-        venv.envconfig.config.option.pdm, venv.path, venv.envconfig.commands_pre
-    )
-    inject_pdm_to_commands(
-        venv.envconfig.config.option.pdm, venv.path, venv.envconfig.commands
-    )
-    inject_pdm_to_commands(
-        venv.envconfig.config.option.pdm, venv.path, venv.envconfig.commands_post
-    )
-
-
-@hookimpl
-def tox_runenvreport(venv: VirtualEnv, action: action.Action):
-    if not detect_pdm_files(venv.path):
-        return
-    command = venv.envconfig.list_dependencies_command
-    for i, arg in enumerate(command):
-        if arg == "python":
-            command[i] = venv.getsupportedinterpreter()
-    venv.envconfig.list_dependencies_command.extend(
-        ["--path", get_env_lib_path(venv.envconfig.config.option.pdm, venv.path)]
-    )

--- a/tox_pdm/plugin4.py
+++ b/tox_pdm/plugin4.py
@@ -1,135 +1,50 @@
 """Plugin specification for Tox 4"""
 from __future__ import annotations
 
-import os
-import shutil
-import sys
 import typing as t
-from pathlib import Path
 
-from tox.config.cli.parser import DEFAULT_VERBOSITY
-from tox.config.sets import EnvConfigSet
-from tox.execute.api import Execute
-from tox.execute.local_sub_process import LocalSubProcessExecuteInstance
+from tox.config.set_env import SetEnv
 from tox.execute.request import StdinSource
 from tox.plugin import impl
-from tox.tox_env.package import Package, PackageToxEnv
-from tox.tox_env.python.api import Python, PythonInfo
-from tox.tox_env.python.package import WheelPackage
-from tox.tox_env.python.pip.pip_install import Pip
-from tox.tox_env.python.runner import PythonRun
-from virtualenv.discovery.builtin import get_interpreter
-
-from tox_pdm.utils import clone_pdm_files, get_env_lib_path, is_same_path, is_sub_array
+from tox.tox_env.python.virtual_env.runner import VirtualEnvRunner
 
 if t.TYPE_CHECKING:
-
     from argparse import ArgumentParser
 
-    from tox.execute.api import ExecuteInstance, ExecuteOptions
-    from tox.execute.request import ExecuteRequest
-    from tox.execute.stream import SyncWrite
-    from tox.tox_env.api import ToxEnvCreateArgs
     from tox.tox_env.register import ToxEnvRegister
 
 
 @impl
 def tox_add_option(parser: ArgumentParser) -> None:
-    os.environ["TOX_TESTENV_PASSENV"] = "PYTHONPATH"
     parser.add_argument("--pdm", default="pdm", help="The executable path of PDM")
 
 
 @impl
 def tox_register_tox_env(register: ToxEnvRegister) -> t.Optional[bool]:
     register.add_run_env(PdmRunner)
-    register.add_package_env(PdmPackageEnv)
     register.default_env_runner = "pdm"
 
 
-class Pdm(Python):
-    def __init__(self, create_args: ToxEnvCreateArgs) -> None:
-        self._executor: t.Optional[Execute] = None
-        self._installer: t.Optional[Pip] = None
-        self._package_path: t.Optional[Path] = None
-        super().__init__(create_args)
-
-    @property
-    def executor(self) -> Execute:
-        if not self._executor:
-            self._executor = PDMRunExecutor(self.options.is_colored)
-        return self._executor
-
-    @property
-    def installer(self) -> Pip:
-        if self._installer is None:
-            self._installer = PipPep582(self)
-        return self._installer
-
-    @property
-    def package_path(self) -> Path:
-        if not self._package_path:
-            self._package_path = Path(
-                get_env_lib_path(self.options.pdm, self.env_dir)
-            ).parent
-        return self._package_path
-
-    @property
-    def runs_on_platform(self) -> str:
-        return sys.platform
-
-    def create_python_env(self) -> None:
-        clone_pdm_files(self.env_dir, self.core["toxinidir"])
-        self.execute(
-            ["pdm", "use", "-f", self.base_python.extra["executable"]], StdinSource.OFF
-        )
-
-    def _get_python(self, base_python: t.List[str]) -> t.Optional[PythonInfo]:
-        interpreter = next(
-            filter(None, (get_interpreter(p, []) for p in base_python)), None
-        )
-        if not interpreter:
-            return None
-        return PythonInfo(
-            implementation=interpreter.implementation,
-            version_info=interpreter.version_info,
-            version=interpreter.version,
-            is_64=(interpreter.architecture == 64),
-            platform=interpreter.platform,
-            extra={"executable": Path(interpreter.system_executable)},
-        )
-
-    def python_cache(self) -> t.Dict[str, t.Any]:
-        base = super().python_cache()
-        base.update({"executable": str(self.base_python.extra["executable"])})
-        return base
-
-    def env_bin_dir(self) -> Path:
-        return self.package_path / ("Scripts" if os.name == "nt" else "bin")
-
-    def env_python(self) -> Path:
-        return t.cast(Path, self.base_python.extra["executable"])
-
-    def env_site_package_dir(self) -> Path:
-        return self.package_path / "lib"
-
-    def prepend_env_var_path(self) -> t.List[Path]:
-        return [self.env_bin_dir]
-
-
-class PdmRunner(Pdm, PythonRun):
+class PdmRunner(VirtualEnvRunner):
     def _setup_env(self) -> None:
         super()._setup_env()
         groups = self.conf["groups"]
-        cmd = ["pdm", "install", "--no-self"]
+        pdm = self.options.pdm
+        cmd = [pdm, "install", "--no-self"]
         for group in groups:
             cmd.extend(("--group", group))
+        if pdm not in self.conf["allowlist_externals"]:
+            self.conf["allowlist_externals"].append(pdm)
+        set_env: SetEnv = self.conf["setenv"]
+        if "VIRTUAL_ENV" not in set_env:
+            set_env.update({"VIRTUAL_ENV": str(self.env_dir)})
         self.execute(cmd, StdinSource.OFF)
-        bin_path = self.env_site_package_dir() / "bin"
-        if not bin_path.exists():
-            return
-        scripts_path = self.env_bin_dir()
-        for file in bin_path.iterdir():
-            shutil.move(os.fspath(file), os.fspath(scripts_path))
+
+    @staticmethod
+    def _load_pass_env(pass_env: list[str]) -> dict[str, str]:
+        env = VirtualEnvRunner._load_pass_env(pass_env)
+        env.update({"PDM_IGNORE_SAVED_PYTHON": "1", "PDM_USE_VENV": "1"})
+        return env
 
     def register_config(self) -> None:
         super().register_config()
@@ -140,100 +55,6 @@ class PdmRunner(Pdm, PythonRun):
             desc="Specify the dependency groups to install",
         )
 
-    @property
-    def _package_tox_env_type(self) -> str:
-        return "pdm-pep-517"
-
     @staticmethod
     def id() -> str:
         return "pdm"
-
-    @property
-    def _external_pkg_tox_env_type(self) -> str:
-        return "virtualenv-cmd-builder"
-
-
-class PdmPackageEnv(Pdm, PackageToxEnv):
-    def register_config(self) -> None:
-        super().register_config()
-        self.conf.add_config(
-            keys=["pkg_dir"],
-            of_type=Path,
-            default=lambda conf, name: self.env_dir / "dist",
-            desc="directory where to put project packages",
-        )
-
-    @property
-    def pkg_dir(self) -> Path:
-        return t.cast(Path, self.conf["pkg_dir"])
-
-    def perform_packaging(self, for_env: EnvConfigSet) -> t.List[Package]:
-        of_type: str = for_env["package"]
-        cmd = [
-            "pdm",
-            "build",
-            "-p",
-            str(self.conf["package_root"]),
-            "-d",
-            str(self.pkg_dir),
-        ]
-        if of_type == "wheel":
-            cmd.append("--no-sdist")
-            suffix = ".whl"
-        else:
-            cmd.append("--no-wheel")
-            suffix = ".tar.gz"
-        self.execute(cmd, StdinSource.OFF)
-        path = next(self.pkg_dir.glob(f"*{suffix}"))
-        package = WheelPackage(path, [])
-        return [package]
-
-    @staticmethod
-    def id() -> str:
-        return "pdm-pep-517"
-
-    def child_pkg_envs(self, run_conf: EnvConfigSet) -> t.Iterator[PackageToxEnv]:
-        return iter(())
-
-
-class PipPep582(Pip):
-    def installed(self) -> t.List[str]:
-        cmd = ["pdm", "list", "--freeze"]
-        result = self._env.execute(
-            cmd=cmd,
-            stdin=StdinSource.OFF,
-            run_id="freeze",
-            show=self._env.options.verbosity > DEFAULT_VERBOSITY,
-        )
-        result.assert_success()
-        return [line.strip() for line in result.out.splitlines() if line.strip()]
-
-
-class PDMRunExecutor(Execute):
-    def build_instance(
-        self,
-        request: ExecuteRequest,
-        options: ExecuteOptions,
-        out: SyncWrite,
-        err: SyncWrite,
-    ) -> "ExecuteInstance":
-        return PDMRunExecuteInstance(request, options, out, err)
-
-
-class PDMRunExecuteInstance(LocalSubProcessExecuteInstance):
-    @property
-    def cmd(self) -> t.Sequence[str]:
-        if self._cmd is None:
-            pdm_exe = self.options._env.options.pdm
-            cmd = self.request.cmd
-            if cmd[0] == "pdm":
-                cmd[0] = pdm_exe
-            if is_same_path(cmd[0], pdm_exe):
-                if "-p" not in cmd and "--project" not in cmd:
-                    cmd[2:2] = ["-p", str(self.options._env.env_dir)]
-            elif is_sub_array(["pip", "install"], cmd):
-                cmd.extend(["-t", get_env_lib_path(pdm_exe, self.options._env.env_dir)])
-            else:
-                cmd = [pdm_exe, "run", "-p", str(self.options._env.env_dir)] + cmd
-            self._cmd = cmd
-        return self._cmd

--- a/tox_pdm/utils.py
+++ b/tox_pdm/utils.py
@@ -1,13 +1,19 @@
 from __future__ import annotations
 
-import inspect
 import os
 import shutil
-import subprocess
 from pathlib import Path
-from typing import List, Sequence
 
 import toml
+
+
+def setup_env() -> None:
+    os.environ.update({"PDM_IGNORE_SAVED_PYTHON": "1", "PDM_USE_VENV": "1"})
+    old_passenv = os.getenv("TOX_TESTENV_PASSENV")
+    new_env = ["PDM_*"]
+    if old_passenv:
+        new_env.append(old_passenv)
+    os.environ["TOX_TESTENV_PASSENV"] = " ".join(new_env)
 
 
 def clone_pdm_files(env_path: str | Path, root: str | Path) -> None:
@@ -38,78 +44,3 @@ def detect_pdm_files(root: str | Path) -> bool:
     with pyproject.open("r") as f:
         toml_data = toml.load(f)
         return "project" in toml_data
-
-
-def set_default_kwargs(func_or_method, **kwargs):
-    """Change the default value for keyword arguments."""
-    func = getattr(func_or_method, "__func__", func_or_method)
-    args = inspect.signature(func).parameters
-    defaults = {k: v.default for k, v in args.items() if v.default is not v.empty}
-    for k, v in kwargs.items():
-        if k in defaults:
-            defaults[k] = v
-    func.__defaults__ = tuple(defaults.values())
-
-
-def get_env_lib_path(pdm_exe: str, env_path: str | Path) -> str:
-    """Return the PEP 582 library path for the given VirtualEnv."""
-    cmd = [pdm_exe, "info", "-p", str(env_path), "--packages"]
-    return os.path.join(subprocess.check_output(cmd).decode().strip(), "lib")
-
-
-NON_PROJECT_COMMANDS = ("cache", "show", "completion")
-
-
-def inject_pdm_to_commands(
-    pdm_exe: str, env_path: str | Path, commands: List[List[str]]
-) -> None:
-    """Inject pdm run to the commands in place.
-
-    Examples:
-        - <cmd> -> pdm run <cmd>
-        - pip install <pkg> -> pdm run pip install <pkg> -t <lib_path>
-    """
-    cmd_prefix = [pdm_exe, "run", "-p", str(env_path)]
-    pip_postfix = ["-t", get_env_lib_path(pdm_exe, env_path)]
-
-    for argv in commands:
-        cmd = argv[0]
-        inject_pos = 0
-        if cmd == "-":
-            cmd = argv[1]
-            inject_pos = 1
-        elif cmd.startswith("-"):
-            cmd = cmd.lstrip("-")
-            argv[:1] = ["-", cmd]
-            inject_pos = 1
-        if argv[inject_pos : inject_pos + 2] == ["pip", "install"] or argv[
-            inject_pos : inject_pos + 4
-        ] == ["python", "-m", "pip", "install"]:
-            argv.extend(pip_postfix)
-        if argv[inject_pos : inject_pos + 3] == ["python", "-m", "pdm"]:
-            argv[inject_pos : inject_pos + 3] = ["pdm"]
-        if argv[inject_pos] == "pdm":
-            argv[inject_pos] = pdm_exe
-            if (
-                inject_pos + 1 < len(argv)
-                and argv[inject_pos + 1] not in NON_PROJECT_COMMANDS
-                and not argv[inject_pos + 1].startswith("-")
-            ):
-                argv[inject_pos + 2 : inject_pos + 2] = ["-p", str(env_path)]
-        else:
-            argv[inject_pos:inject_pos] = cmd_prefix
-
-
-def is_same_path(left: str | Path, right: str | Path) -> bool:
-    """Check if the two paths are the same"""
-    return Path(left).expanduser().resolve() == Path(right).expanduser().resolve()
-
-
-def is_sub_array(source: Sequence, target: Sequence) -> bool:
-    """Check if the given source is a sub-array of the target"""
-    if len(source) > len(target):
-        return False
-    for i in range(0, len(target) - len(source) + 1):
-        if target[i : i + len(source)] == source:
-            return True
-    return False


### PR DESCRIPTION
Currently tox-pdm plugin is using PEP 582 layout inside tox envs.
However, this requires many hacks, making the whole system unrobust, and causing issues like #25.

Since tox is built on top of virtualenv, it is better to use the same pattern. Fortunately, PDM also supports venv layout, with a little configuration.

So this PR swtich back to the venv layout and remove a lot of hacks. Users should not notice any change in the interface perspective.