### PR TITLE
use sync instead of install

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -109,3 +109,20 @@ def test_use_pdm_shell_scripts(tmpdir):
         commands = lint-shell
         """,
     )
+
+
+def test_pdm_install_not_sync(tmpdir):
+    execute_config(
+        tmpdir,
+        """
+        [tox]
+        envlist = py3
+        passenv = LD_PRELOAD
+        isolated_build = True
+
+        [testenv]
+        groups = lint
+        pdm_sync = False
+        commands = flake8 --version
+        """,
+    )

--- a/tox_pdm/plugin3.py
+++ b/tox_pdm/plugin3.py
@@ -22,6 +22,9 @@ def tox_addoption(parser: config.Parser) -> Any:
     parser.add_testenv_attribute(
         "groups", "line-list", "Specify the dependency groups to install"
     )
+    parser.add_testenv_attribute(
+        "pdm_sync", "bool", "Disable to use 'pdm install' instead of 'pdm sync'.", True
+    )
     setup_env()
     parser.add_argument("--pdm", default="pdm", help="The executable path of PDM")
 
@@ -40,9 +43,10 @@ def tox_configure(config: config.Config):
 @hookimpl
 def tox_testenv_install_deps(venv: VirtualEnv, action: action.Action) -> Any:
     groups = venv.envconfig.groups or []
+    op = "sync" if venv.envconfig.pdm_sync else "install"
     if not venv.envconfig.skip_install or groups:
         action.setactivity("pdminstall", groups)
-        args = [venv.envconfig.config.option.pdm, "install"]
+        args = [venv.envconfig.config.option.pdm, op]
         if "default" in groups:
             groups.remove("default")
         elif venv.envconfig.skip_install:

--- a/tox_pdm/plugin4.py
+++ b/tox_pdm/plugin4.py
@@ -34,7 +34,8 @@ class PdmRunner(VirtualEnvRunner):
         super()._setup_env()
         groups = self.conf["groups"]
         pdm = self.options.pdm
-        cmd = [pdm, "install", "--no-self"]
+        op = "sync" if self.conf["pdm_sync"] else "install"
+        cmd = [pdm, op, "--no-self"]
         for group in groups:
             cmd.extend(("--group", group))
         if pdm not in self.conf["allowlist_externals"]:
@@ -57,6 +58,12 @@ class PdmRunner(VirtualEnvRunner):
             of_type=t.List[str],
             default=[],
             desc="Specify the dependency groups to install",
+        )
+        self.conf.add_config(
+            "pdm_sync",
+            of_type=bool,
+            default=True,
+            desc="Disable to use 'pdm install' instead of 'pdm sync'.",
         )
 
     @staticmethod


### PR DESCRIPTION
`pdm sync` is used by default instead of `pdm install`. This takes advantage of PDM's lock file to run tests in a known good environment.

If `pdm_sync = False` is set in the tox env config, `pdm install` is used instead. I wasn't sure if this was necessary, I think it would be fine to leave it out too.

closes #30